### PR TITLE
Update puppet-lint.yml

### DIFF
--- a/.github/workflows/puppet-lint.yml
+++ b/.github/workflows/puppet-lint.yml
@@ -9,34 +9,29 @@
 # More details at https://github.com/puppetlabs/puppet-lint/
 
 name: puppet-lint
+
 on:
   push:
-    branches:
-      - main
+    branches: [ "main" ]
   pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '34 9 * * 6'
+
+permissions:
+  contents: read
 
 jobs:
   puppet-lint:
-    runs-on: ubuntu-24.04-x64
+    name: Run puppet-lint scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
 
     steps:
-      - name: Set up Ruby
-        run: |
-          # Install rbenv
-          curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-installer | bash
-          export PATH="$HOME/.rbenv/bin:$PATH"
-          eval "$(rbenv init -)"
-          
-          # Install Ruby using rbenv
-          rbenv install 2.7.0
-          rbenv global 2.7.0
-          # Verify installation
-          ruby --version
-      - name: Install dependencies
-        run: bundle install --jobs 4 --retry 3
-
-      - name: Run puppet-lint
-        run: bundle exec puppet-lint ./
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -45,44 +40,6 @@ jobs:
         with:
           ruby-version: 2.7
           bundler-cache: true
-
-      - name: Install puppet-lint
-        run: gem install puppet-lint
-
-      - name: Run puppet-lint
-        run: puppet-lint . --sarif > puppet-lint-results.sarif
-        continue-on-error: true
-
-      - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: puppet-lint-results.sarif
-          wait-for-processing: true
-          
-# Updated steps in .github/workflows/puppet-lint.yml
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-  # Install Ruby manually using ruby-build
-      - name: Install ruby-build
-        run: |
-         sudo apt-get update
-         sudo apt-get install -y build-essential libssl-dev zlib1g-dev
-         git clone https://github.com/rbenv/ruby-build.git ~/.ruby-build
-         sudo ~/.ruby-build/install.sh
-      - name: Install Ruby 2.7
-        run: |
-          ruby-build 2.7.0 $RUNNER_TOOL_CACHE/ruby/2.7.0
-          echo "Ruby installed to $RUNNER_TOOL_CACHE/ruby/2.7.0"
-  # Add Ruby to PATH
-      - name: Configure Ruby PATH
-        run: echo "$RUNNER_TOOL_CACHE/ruby/2.7.0/bin" >> $GITHUB_PATH
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
-        with:
-            ruby-version: 2.7
-            bundler-cache: true
 
       - name: Install puppet-lint
         run: gem install puppet-lint


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Streamline the puppet-lint GitHub Actions workflow by modernizing triggers, runner, permissions, and removing manual Ruby setup steps

Enhancements:
- Use array shorthand for push and pull_request branches
- Add a weekly cron schedule for lint scans
- Switch the runner to ubuntu-latest and name the job
- Centralize and restrict workflow and job permissions

Chores:
- Remove manual Ruby installation, dependency setup, and puppet-lint invocation steps