### PR TITLE
Create action.yml

### DIFF
--- a/.github/actions/setup-env /action.yml
+++ b/.github/actions/setup-env /action.yml
@@ -1,0 +1,43 @@
+name: Setup env
+description: Sets up node and pnpm
+
+inputs:
+  pnpm-version:
+    description: Version of pnpm to install
+    required: false
+    default: "9"
+  node-version:
+    description: Version of node to install
+    required: false
+    default: "18"
+  cache-save:
+    description: Whether to save the pnpm cache
+    required: false
+    default: "false"
+outputs:
+  cache-hit:
+    description: Whether the cache was restored
+    value: ${{ steps.setup-node.outputs.cache-hit || steps.cache-restore.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+    - uses: actions/setup-node@v4
+      id: setup-node
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.cache-save == 'true' && 'pnpm' || '' }}
+        cache-dependency-path: "**/pnpm-lock.yaml"
+    - id: pnpm
+      if: inputs.cache-save == 'false'
+      run: pnpm store path --silent | xargs -I {} -0 echo "path={}" | tee -a $GITHUB_OUTPUT
+      shell: bash
+    - uses: actions/cache/restore@v4
+      id: cache-restore
+      if: inputs.cache-save == 'false'
+      with:
+        path: ${{ steps.pnpm.outputs.path }}
+        key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Add a composite GitHub Action to set up pnpm and Node with configurable versions and optional caching

New Features:
- Introduce .github/actions/setup-env action to install Node and pnpm based on inputs

CI:
- Add action.yml defining inputs (pnpm-version, node-version, cache-save), steps to install tools, and optional cache restore/save
- Expose a cache-hit output reflecting whether dependency cache was restored