### PR TITLE
Update hardhat-ledger-ci.yml

### DIFF
--- a/.github/workflows/hardhat-ledger-ci.yml
+++ b/.github/workflows/hardhat-ledger-ci.yml
@@ -1,5 +1,4 @@
 name: hardhat-ledger CI
-
 on:
   push:
     branches:
@@ -29,16 +28,16 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-ledger on Windows with Node 16
+    name: Test hardhat-ledger on Windows with Node 18
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -48,18 +47,18 @@ jobs:
         run: pnpm test
 
   test_on_macos:
-    name: Test hardhat-ledger on MacOS with Node 16
+    name: Test hardhat-ledger on MacOS with Node 18
     runs-on: macos-latest
     # disable until actions/virtual-environments#4896 is fixed
     if: ${{ false }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -73,12 +72,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 18, 20]
+        node: [ 18, 20, 22 ]
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Upgrade Hardhat Ledger CI workflow to use updated GitHub Actions, pnpm, and Node.js versions

Enhancements:
- Bump GitHub Actions versions: actions/checkout to v3 and pnpm/action-setup to v3
- Upgrade pnpm setup to version 9
- Update Node.js versions in Windows and MacOS tests from 16 to 18
- Adjust CI matrix to test on Node 18, 20, and 22