### PR TITLE
Update hardhat-network-forking-ci.yml

### DIFF
--- a/.github/workflows/hardhat-network-forking-ci.yml
+++ b/.github/workflows/hardhat-network-forking-ci.yml
@@ -37,18 +37,18 @@ jobs:
     name: Test Hardhat Network's forking functionality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v3
         with:
-          version: 8
-      - uses: actions/setup-node@v2
+          version: 9
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Cache network requests
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             packages/hardhat-core/test/internal/hardhat-network/provider/.hardhat_node_test_cache


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Update hardhat network forking CI workflow to use the latest GitHub Actions versions and bump Node.js and PNPM runtime versions

Build:
- Upgrade actions/checkout, pnpm/action-setup, actions/setup-node, and actions/cache to v3
- Bump PNPM version from 8 to 9 in the pnpm setup action
- Update Node.js version from 16 to 18 in the setup-node action