### PR TITLE
Update hardhat-network-helpers-ci.yml

### DIFF
--- a/.github/workflows/hardhat-network-helpers-ci.yml
+++ b/.github/workflows/hardhat-network-helpers-ci.yml
@@ -1,5 +1,4 @@
 name: hardhat-network-helpers CI
-
 on:
   push:
     branches: [$default-branch]
@@ -26,16 +25,16 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-network-helpers on Windows with Node 16
+    name: Test hardhat-network-helpers on Windows with Node 18
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -47,18 +46,18 @@ jobs:
         run: pnpm test
 
   test_on_macos:
-    name: Test hardhat-network-helpers on MacOS with Node 16
+    name: Test hardhat-network-helpers on MacOS with Node 18
     runs-on: macos-latest
     # disable until actions/virtual-environments#4896 is fixed
     if: ${{ false }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v3
         with:
-          version: 8
-      - uses: actions/setup-node@v2
+          version: 9
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -74,13 +73,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 18, 20]
+        node: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v3
         with:
-          version: 8
-      - uses: actions/setup-node@v2
+          version: 9
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: "pnpm"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Update the hardhat-network-helpers CI workflow to use current Node.js versions and the latest GitHub Actions steps.

Enhancements:
- Test Windows and macOS CI jobs on Node 18 and update the Ubuntu matrix to Node 18, 20, and 22 (dropping Node 16)
- Upgrade actions/checkout to v3, pnpm/action-setup to v3 with pnpm 9, and actions/setup-node to v3 across CI jobs