### PR TITLE
Enhance CircleCI config with deployment steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine.
 # See: https://circleci.com/docs/configuration-reference
-
 version: 2.1
 executors:
   my-custom-executor:
@@ -11,16 +10,39 @@ executors:
           # visit app.circleci.com/settings/project/github/Dargon789/hardhat-project/environment-variables
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
+          
 jobs:
   web3-defi-game-project-:
-
     executor: my-custom-executor
     steps:
       - checkout
       - run: |
-          # echo Hello, World!
+          # This job is intentionally a no-op. Add build, test, or deployment steps here as needed.
+          echo "No operation"
 
 workflows:
   my-custom-workflow:
     jobs:
-      - web3-defi-game-project-
+       web3-defi-game-project-:
+    executor: my-custom-executor
+    steps:
+      - checkout
+      - run: |
+          # This job is intentionally a no-op. Add build, test, or deployment steps here as needed.
+          echo "No operation"      
+      - run:
+        name: Plan a deploy
+        command: |
+            circleci run release plan \
+            --environment-name="web3-defi" \
+            --component-name="sequence-kit" \
+            --target-version="<some-version-name>"
+      # Your job here doing the actual deployment
+      - run:
+        name: Update a deploy to SUCCESS
+        command: circleci run release update --status=SUCCESS 
+        when: on_success 
+      - run:
+        name: Update planned deploy to FAILED
+        command: circleci run release update --status=FAILED 
+        when: on_fail


### PR DESCRIPTION
Updated CircleCI configuration to include deployment steps and modified job definitions.

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Enhance CircleCI pipeline by reorganizing job definitions, clarifying no-op placeholders, and integrating deployment steps for planning and status updates

Enhancements:
- Clarify CircleCI config by adding an explicit `jobs:` section

CI:
- Update the existing web3-defi-game-project- job with a descriptive no-op placeholder
- Add deployment steps in the workflow to plan a release and update its status on success or failure

Deployment:
- Introduce `circleci run release` commands to handle deployment planning and status updates