### PR TITLE
Update check-docs-site.yml

### DIFF
--- a/.github/workflows/check-docs-site.yml
+++ b/.github/workflows/check-docs-site.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 10
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: "pnpm"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Restrict the docs site check workflow to run only on the main branch and update its Node.js and pnpm versions to current ones.

Build:
- Limit the check-docs-site GitHub Actions workflow to trigger only on pushes to the main branch instead of all branches.
- Bump the pnpm version used in the docs check workflow from 8 to 10.
- Upgrade the Node.js version used in the docs check workflow from 16 to 22.