### PR TITLE
Add .vercel/ to .gitignore for Vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ Cargo.lock
 .vscode/
 *.code-workspace
 /node-scrypt
+
+# vercel deploy
+.vercel/


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Build:
- Add the .vercel/ directory to .gitignore to prevent Vercel deployment metadata from being committed.