### PR TITLE
bump @ensdomains/ens-contracts

### DIFF
--- a/.yarn/unplugged/pnpm-npm-10.28.2-9e2a8656f8/node_modules/pnpm/dist/node_modules/fdir/LICENSE
+++ b/.yarn/unplugged/pnpm-npm-10.28.2-9e2a8656f8/node_modules/pnpm/dist/node_modules/fdir/LICENSE
@@ -1,7 +1,0 @@
-Copyright 2023 Abdullah Atta
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -25,11 +25,15 @@ export function fromZodError(
     prefix?: string
   } = {},
 ): ValidationError {
+  const joinPath = (arr: (string | number)[]) => {
     return arr.reduce<string>((acc, value) => {
-      if (typeof value === 'number') return `${acc}[${value}]`
+      if (typeof value === 'number') return acc + '[' + value + ']'
       const separator = acc === '' ? '' : '.'
+      return acc + separator + value
     }, '')
   }
+
+  const reason = zError.issues
 
     // limit max number of issues printed in the reason section
     .slice(0, maxIssuesInMessage)

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -34,7 +34,6 @@ export function fromZodError(
   }
 
   const reason = zError.issues
-
     // limit max number of issues printed in the reason section
     .slice(0, maxIssuesInMessage)
     // format error message

--- a/packages/core/src/actions/getConnectorClient.ts
+++ b/packages/core/src/actions/getConnectorClient.ts
@@ -105,11 +105,12 @@ export async function getConnectorClient<
 
   // Check connector using same chainId as connection
   const connectorChainId = await connection.connector.getChainId()
-  if (connectorChainId !== connection.chainId)
+  if (connectorChainId !== connection.chainId) {
     throw new ConnectorChainMismatchError({
       connectionChainId: connection.chainId,
       connectorChainId,
     })
+  }
 
   // If connector has custom `getClient` implementation
   type Return = GetConnectorClientReturnType<config, chainId>

--- a/packages/core/src/actions/getConnectorClient.ts
+++ b/packages/core/src/actions/getConnectorClient.ts
@@ -105,7 +105,9 @@ export async function getConnectorClient<
 
   // Check connector using same chainId as connection
   const connectorChainId = await connection.connector.getChainId()
+  if (connectorChainId !== connection.chainId)
     throw new ConnectorChainMismatchError({
+      connectionChainId: connection.chainId,
       connectorChainId,
     })
 


### PR DESCRIPTION
## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](./CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:

<!--
Thank you for using Wagmi and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] None of the above.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Align error handling with updated ENS contracts and improve connector chain validation.

Bug Fixes:
- Throw a ConnectorChainMismatchError when the connector chain ID differs from the active connection chain ID, including both IDs in the error context.

Enhancements:
- Refine construction of validation error paths and prepare error reasons for clearer Zod validation messages.